### PR TITLE
IGNITE-11547 Disabling Persistence on client node

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -2877,6 +2877,12 @@ public class GridCacheProcessor extends GridProcessorAdapter {
 
         boolean persistenceEnabled = recoveryMode || sharedCtx.localNode().isClient() ? desc.persistenceEnabled() :
             dataRegion != null && dataRegion.config().isPersistenceEnabled();
+        
+        if (persistenceEnabled && ctx.config().isClientMode()) {
+            U.warn(log, "Persistent Store is not supported on client nodes (Persistent Store's" +
+                    " configuration will be overrided with false flag).");
+            persistenceEnabled = false;
+        }
 
         CacheGroupContext grp = new CacheGroupContext(sharedCtx,
             desc.groupId(),


### PR DESCRIPTION
As per the code flow when client node is set to true it should use PageMemoryNoStoreImpl.java, and when we use this it is failing with class cast exception GridCacheOffheapManager#getOrAllocateCacheMetas() method as we enabled Persistence in IgniteConfiguration. Disabling the persistence flag(setting it to false) will make to go through IgniteCacheOffheapManagerImpl.java which should be the actual flow for client node.